### PR TITLE
feat: Add GitHub Actions CI/CD pipeline

### DIFF
--- a/.github/workflows/.gitkeep
+++ b/.github/workflows/.gitkeep
@@ -1,0 +1,1 @@
+# This is a placeholder file to ensure the directory is created.

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,102 @@
+name: CI/CD Pipeline
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  backend_build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Install backend dependencies
+        run: npm install
+
+      - name: Build backend
+        run: npx tsc # Assuming tsconfig.json is set up correctly
+
+      - name: Archive backend artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: backend-artifact
+          path: |
+            dist/
+            node_modules/
+            package.json
+            package-lock.json
+            # Add any other necessary backend files or folders
+
+  frontend_build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Install frontend dependencies
+        working-directory: ./frontend
+        run: npm install
+
+      - name: Build frontend
+        working-directory: ./frontend
+        run: npm run build
+
+      - name: Lint frontend
+        working-directory: ./frontend
+        run: npm run lint
+
+      - name: Archive frontend artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: frontend-artifact
+          path: |
+            frontend/.next/
+            frontend/public/
+            frontend/package.json
+            frontend/package-lock.json
+            frontend/next.config.ts
+            # Add any other necessary frontend files like server.js if using custom server with Next.js
+
+  deploy:
+    runs-on: ubuntu-latest
+    needs: [backend_build, frontend_build] # Depends on successful builds
+    steps:
+      - name: Download backend artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: backend-artifact
+          path: backend-artifact # Download to a specific directory
+
+      - name: Download frontend artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: frontend-artifact
+          path: frontend-artifact # Download to a specific directory
+
+      - name: List downloaded artifacts (for verification)
+        run: |
+          echo "Backend artifact contents:"
+          ls -R backend-artifact
+          echo ""
+          echo "Frontend artifact contents:"
+          ls -R frontend-artifact
+
+      - name: Deploy to server
+        run: |
+          echo "Deployment steps would go here."
+          echo "For example, copying files to a server via SCP, then SSHing to restart a service."
+          echo "Or, if using Docker, building images and pushing to a registry, then updating a service."
+          echo "Current artifacts are in ./backend-artifact and ./frontend-artifact"

--- a/README.md
+++ b/README.md
@@ -1,2 +1,29 @@
 ### Coin Dashboard
 #### This repo is for a personal project for cataloging coins into a database for tracking.
+
+## CI/CD Pipeline
+
+This project uses GitHub Actions for CI/CD. The pipeline is defined in `.github/workflows/main.yml` and includes the following jobs:
+
+1.  **`backend_build`**:
+    *   Checks out the code.
+    *   Sets up Node.js.
+    *   Installs backend dependencies (`npm install`).
+    *   Builds the backend TypeScript code (`npm run build`, which runs `tsc`).
+    *   Archives the `dist/` directory, `node_modules/`, and `package.json` files as `backend-artifact`.
+
+2.  **`frontend_build`**:
+    *   Checks out the code.
+    *   Sets up Node.js.
+    *   Installs frontend dependencies (`npm install` in the `frontend` directory).
+    *   Builds the Next.js frontend (`npm run build` in the `frontend` directory).
+    *   Lints the frontend code (`npm run lint` in the `frontend` directory).
+    *   Archives the `frontend/.next/`, `frontend/public/`, `frontend/package.json`, `frontend/package-lock.json`, and `frontend/next.config.ts` as `frontend-artifact`.
+
+3.  **`deploy`**:
+    *   This job runs after successful completion of `backend_build` and `frontend_build`.
+    *   Downloads `backend-artifact` and `frontend-artifact`.
+    *   Currently, this job is a placeholder and will list the contents of the downloaded artifacts.
+    *   **To implement deployment:** Modify the `deploy` job in `.github/workflows/main.yml` to include scripts for deploying the artifacts to your server (e.g., using SCP/SSH, Docker push, etc.).
+
+The pipeline is triggered on pushes and pull requests to the `main` branch.

--- a/package.json
+++ b/package.json
@@ -4,7 +4,9 @@
   "main": "index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "dev": "next dev"
+    "dev": "next dev",
+    "build": "tsc",
+    "start": "node dist/server.js"
   },
   "keywords": [],
   "author": "",


### PR DESCRIPTION
Sets up a GitHub Actions workflow to build the backend and frontend, and archive their artifacts.

The pipeline includes three jobs:
- backend_build: Installs dependencies, compiles TypeScript, and archives the backend artifact.
- frontend_build: Installs dependencies, builds the Next.js application, lints, and archives the frontend artifact.
- deploy: Downloads both artifacts. This job is a placeholder for actual deployment scripts.

The root package.json has been updated with 'build' and 'start' scripts for the backend. Pipeline documentation has been added to README.md.